### PR TITLE
お題が何も出なかったときにお題を自動で生成

### DIFF
--- a/pages/_id/decideQuestion/index.vue
+++ b/pages/_id/decideQuestion/index.vue
@@ -61,6 +61,7 @@
             :vote-id="question.id"
             :vote-number="question.numberOfVotes"
           />
+          <li v-if="questions.length == 0">お題を生成中…</li>
         </ul>
 
         <div class="flex flex-col items-center justify-center mt-4">
@@ -109,7 +110,14 @@ export default {
       const url = '/theme/read/' + this.$store.state.roomId
       const response = await this.$axios.get(url, '')
       if (response.status === 200) {
-        this.questions = response.data.themes
+        if (response.data.themes.length > 0) {
+          this.questions = response.data.themes
+        } else if (this.$store.state.host) {
+          this.$axios.post('/theme/create/' + this.$store.state.roomId, {
+            theme: 'ヤフーのいいところは？',
+            name: '(自動生成)'
+          })
+        }
       }
     },
     setQuestionInterval() {


### PR DESCRIPTION
close: #44 

## 確認！

- [ ] デバック用のコメントやログ出力を消した
- [ ] タイトルを `issue 件名` + `issue No` に設定した
- [ ] `close: #xx` と Issue 番号を先頭に記述した
- [ ] `Reviewers` を設定した
- [ ] `Assignees` を設定した(assign yourself)
- [ ] `Want review` のラベルを設定した

## PR で対応したこと
お題が出なかったときに、ホストが投票画面をロードしたタイミングでお題を自動で生成するようにしました
本来想定していない機能なのでお題は「ヤフーのいいところは」しか出ません
回答は誰も出さなくても進行することを確認しました

## 動作確認
ローカルで確認済み

## 補足
