### PR TITLE
空欄でニックネームを登録できないようにする

### DIFF
--- a/pages/_id/index.vue
+++ b/pages/_id/index.vue
@@ -67,7 +67,7 @@
               <button
                 class="w-32 h-11 pt-0.5 mt-4 bg-yellow-50 hover:opacity-80 border-4 border-my-black rounded-xl text-lg font-bold button-shadow active:button-shadow-none active:transform active:translate-y-1"
                 :disabled="isEntered"
-                @click.once="sendNickName"
+                @click="sendNickName"
               >
                 決定
               </button>
@@ -198,15 +198,17 @@ export default {
       }
     },
     async sendNickName() {
-      const url = '/room/guests/' + this.$store.state.roomId
-      const response = await this.$axios.post(url, {
+      if (this.nickName !== '') {
+        const url = '/room/guests/' + this.$store.state.roomId
+        const response = await this.$axios.post(url, {
         name: String(this.nickName)
-      })
-      if (response.status === 200) {
-        this.isEntered = true
-        this.$store.commit('setNickName', String(this.nickName))
-        if (!this.host) {
-          this.wait()
+        })
+        if (response.status === 200) {
+          this.isEntered = true
+          this.$store.commit('setNickName', String(this.nickName))
+          if (!this.host) {
+            this.wait()
+          }
         }
       }
     },


### PR DESCRIPTION
close: #53

## 確認！

- [ ] デバック用のコメントやログ出力を消した
- [ ] タイトルを `issue 件名` + `issue No` に設定した
- [ ] `close: #xx` と Issue 番号を先頭に記述した
- [ ] `Reviewers` を設定した
- [ ] `Assignees` を設定した(assign yourself)
- [ ] `Want review` のラベルを設定した

## PR で対応したこと
ニックネーム登録ボタンのonceを外して、空白を判定して空白時は何も処理を行わない

## 動作確認
ローカルで確認済み

## 補足
